### PR TITLE
Add StopTest exception handling

### DIFF
--- a/lib/rubyslim/list_executor.rb
+++ b/lib/rubyslim/list_executor.rb
@@ -1,5 +1,6 @@
 require "rubyslim/statement"
 require "rubyslim/statement_executor"
+require "rubyslim/slim_error"
 
 class ListExecutor
   def initialize()
@@ -7,6 +8,14 @@ class ListExecutor
   end
 
   def execute(instructions)
-    instructions.collect {|instruction| Statement.execute(instruction, @executor)}
+    results = []
+    instructions.each do |instruction|
+      result = Statement.execute(instruction, @executor)
+      results << result
+      if result[1] =~ /^STOP/
+        return results
+      end
+    end
+    return results
   end
 end

--- a/lib/rubyslim/statement.rb
+++ b/lib/rubyslim/statement.rb
@@ -33,7 +33,12 @@ class Statement
     rescue SlimError => e
       [id, EXCEPTION_TAG + e.message]
     rescue Exception => e
-      [id, EXCEPTION_TAG + e.message + "\n" + e.backtrace.join("\n")]
+      message = EXCEPTION_TAG + e.message + "\n" + e.backtrace.join("\n")
+      if e.class.to_s =~ /StopTest/
+        [id, "STOP" + message]
+      else
+        [id, message]
+      end
     end
 
   end


### PR DESCRIPTION
According to:

```
http://fitnesse.org/FitNesse.UserGuide.SliM.ExceptionHandling
```

When an exception is raised with 'StopTest' in its name, the test should be aborted (in contrast with the default Slim behavior, which is to continue anyway). This feature was apparently not implemented in Rubyslim; this commit implements it. Whenever a generic exception is caught by the statement executor, if its name contains 'StopTest', then the string 'STOP' is prepended to the usual exception message. This 'STOP' string is then checked by the list executor, and the test is aborted immediately if it's found.
