### PR TITLE
Add Gemfile (Bundler)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+gem 'rspec', '~> 1.3.0'
+gem 'rcov'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    rake (0.9.2)
+    rcov (0.9.10)
+    rspec (1.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rcov
+  rspec (~> 1.3.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+require "rubygems"
+require "bundler/setup"
+
 require 'rake'
 #require 'rcov/rcovtask'
 require 'spec/rake/spectask'


### PR DESCRIPTION
Currently, if you have only the latest RSpec installed, specs will fail with
"no such file to load -- spec/rake/spectask". You can infer the correct version
by examining the gemspec, but using Bundler to manage dependencies will
ensure the correct version always gets loaded.

To use:

First install bundler, and the gems rubyslim depends on:
  $ gem install bundler
  $ bundle install

After that, you can use it like normal:
  $ rake spec
