### PR TITLE
Made it work for 1.9.3 as far as i can see, probably incompatible with < 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 *.iws
 .DS_Store
 .idea
-
+.rvmrc
+Gemfile
+Gemfile.lock

--- a/bin/rubyslim
+++ b/bin/rubyslim
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-
+# encoding: UTF-8
 require 'rubyslim/ruby_slim'
-require 'jcode'
-$KCODE="UTF8"
+require 'jcode' if RUBY_VERSION.to_f < 1.9
+
 
 port = ARGV[0].to_i
 rubySlim = RubySlim.new

--- a/lib/rubyslim/list_deserializer.rb
+++ b/lib/rubyslim/list_deserializer.rb
@@ -1,4 +1,5 @@
-require 'jcode'
+# encoding: UTF-8
+require 'jcode' if RUBY_VERSION.to_f < 1.9
 
 module ListDeserializer
   class SyntaxError < Exception
@@ -31,7 +32,7 @@ module ListDeserializer
         item = @string[@pos...@pos+length_of_item]
         length_in_bytes = length_of_item
 
-        until (item.jlength > length_of_item) do
+        until (item.length > length_of_item) do
           length_in_bytes += 1
           item = @string[@pos...@pos+length_in_bytes]
         end

--- a/lib/rubyslim/list_executor.rb
+++ b/lib/rubyslim/list_executor.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "rubyslim/statement"
 require "rubyslim/statement_executor"
 

--- a/lib/rubyslim/list_serializer.rb
+++ b/lib/rubyslim/list_serializer.rb
@@ -1,4 +1,5 @@
-require 'jcode'
+# encoding: UTF-8
+require 'jcode' if RUBY_VERSION.to_f < 1.9
 
 module ListSerializer
   # Serialize a list according to the SliM protocol.
@@ -29,7 +30,7 @@ module ListSerializer
       item = "null" if item.nil?
       item = serialize(item) if item.is_a?(Array)
       item = item.to_s
-      result += length_string(item.jlength)
+      result += length_string(item.length)
       result += item + ":"
     end
 

--- a/lib/rubyslim/ruby_slim.rb
+++ b/lib/rubyslim/ruby_slim.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "rubyslim/socket_service"
 require "rubyslim/list_deserializer"
 require "rubyslim/list_serializer"

--- a/lib/rubyslim/slim_error.rb
+++ b/lib/rubyslim/slim_error.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class SlimError < Exception
 
 end

--- a/lib/rubyslim/slim_helper_library.rb
+++ b/lib/rubyslim/slim_helper_library.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class SlimHelperLibrary
   ACTOR_INSTANCE_NAME = "scriptTableActor"
   attr_accessor :executor

--- a/lib/rubyslim/socket_service.rb
+++ b/lib/rubyslim/socket_service.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'socket'
 require 'thread'
 

--- a/lib/rubyslim/statement.rb
+++ b/lib/rubyslim/statement.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "rubyslim/statement_executor"
 
 class Statement

--- a/lib/rubyslim/statement_executor.rb
+++ b/lib/rubyslim/statement_executor.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "rubyslim/slim_error"
 require "rubyslim/statement"
 require "rubyslim/table_to_hash_converter"
@@ -76,6 +77,7 @@ class StatementExecutor
   def require_class(class_name)
     with_each_fully_qualified_class_name(class_name) do |fully_qualified_name|
       begin
+        $: << Dir.pwd
         require make_path_to_class(fully_qualified_name)
         return
       rescue LoadError

--- a/lib/rubyslim/table_to_hash_converter.rb
+++ b/lib/rubyslim/table_to_hash_converter.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'rexml/document'
 
 class TableToHashConverter

--- a/lib/test_module/library_new.rb
+++ b/lib/test_module/library_new.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module TestModule
   class LibraryNew
     attr_reader :called

--- a/lib/test_module/library_old.rb
+++ b/lib/test_module/library_old.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module TestModule
   class LibraryOld
     attr_reader :called

--- a/lib/test_module/should_not_find_test_slim_in_here/test_slim.rb
+++ b/lib/test_module/should_not_find_test_slim_in_here/test_slim.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module TestModule::ShouldNotFindTestSlimInHere
   class TestSlim
     def return_string

--- a/lib/test_module/simple_script.rb
+++ b/lib/test_module/simple_script.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class SimpleScript
   def set_arg(arg)
     @arg = arg

--- a/lib/test_module/test_chain.rb
+++ b/lib/test_module/test_chain.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class TestChain
   def echo_boolean(b)
     b

--- a/lib/test_module/test_slim.rb
+++ b/lib/test_module/test_slim.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'ostruct'
 
 module TestModule

--- a/lib/test_module/test_slim_with_arguments.rb
+++ b/lib/test_module/test_slim_with_arguments.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module TestModule
   class TestSlimWithArguments
     def initialize(arg)

--- a/lib/test_module/test_slim_with_no_sut.rb
+++ b/lib/test_module/test_slim_with_no_sut.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module TestModule
   class TestSlimWithNoSut
 

--- a/rubyslim.gemspec
+++ b/rubyslim.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   s.email = "unclebob@cleancoder.com"
   s.platform = Gem::Platform::RUBY
 
-  s.add_development_dependency 'rspec', '~> 1.3.0'
-  s.add_development_dependency 'rcov'
+  s.add_development_dependency 'rspec', '2.8.0'
+  s.add_development_dependency 'simplecov'
 
   s.files = `git ls-files`.split("\n")
   s.require_path = 'lib'

--- a/spec/instance_creation_spec.rb
+++ b/spec/instance_creation_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "statement_executor"
 

--- a/spec/it8f_spec.rb
+++ b/spec/it8f_spec.rb
@@ -1,8 +1,10 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe "characters" do
   it "should be able to deal with it8f chars" do
     "Köln".should == "Köln"
-    "Köln".size.should == 5
+    "Köln".size.should == 4
+    "Köln".bytesize.should == 5
   end
 end

--- a/spec/list_deserializer_spec.rb
+++ b/spec/list_deserializer_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "list_serializer"
 require "list_deserializer"

--- a/spec/list_executor_spec.rb
+++ b/spec/list_executor_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "statement_executor"
 require "list_executor"

--- a/spec/list_serialzer_spec.rb
+++ b/spec/list_serialzer_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "list_serializer"
 

--- a/spec/method_invocation_spec.rb
+++ b/spec/method_invocation_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "statement_executor"
 
@@ -30,7 +31,8 @@ describe StatementExecutor do
       @test_slim.should_receive(:return_value).and_return("Español")
       val = @executor.call("test_slim", "return_value")
       val.should == "Español"
-      val.jlength.should == 7
+      val.bytesize.should == 8
+      val.size.should == 7
     end
 
 

--- a/spec/slim_helper_library_spec.rb
+++ b/spec/slim_helper_library_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require 'slim_helper_library'
 require 'statement_executor'

--- a/spec/socket_service_spec.rb
+++ b/spec/socket_service_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'test/unit'
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require 'socket_service'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
+# encoding: UTF-8
 $: << File.expand_path(File.dirname(__FILE__) + "/../lib/rubyslim")
 require "rubygems"
-require "spec"
-require 'jcode'
-$KCODE="UTF8"
+require 'jcode' if RUBY_VERSION.to_f < 1.9
 require 'timeout'

--- a/spec/statement_executor_spec.rb
+++ b/spec/statement_executor_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "statement_executor"
 

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "statement"
 

--- a/spec/table_to_hash_converter_spec.rb
+++ b/spec/table_to_hash_converter_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require 'table_to_hash_converter'
 


### PR DESCRIPTION
Following is changed:
- jcode is not in ruby 1.9 anymore. So removed all dependencies there.
- jlength replaced with size.
- added '# encoding: UTF-8', apparently that is the new $KCODE. I did not find any other way of doing it for all files.
- added Dir.pwd to ruby load paths. For some reason it is not picking up the "!path's" from fitnesse. I don't know  when this is set? This should be fixed maybe you can help? See line 80 in statement_executor.rb
