### PR TITLE
Update rubyslim to work with Ruby 1.9.3

### DIFF
--- a/bin/rubyslim
+++ b/bin/rubyslim
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$:.unshift(File.expand_path(File.dirname(__FILE__) + "/../lib/"))
+
 require 'rubyslim/ruby_slim'
 
 port = ARGV[0].to_i

--- a/bin/rubyslim
+++ b/bin/rubyslim
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'rubyslim/ruby_slim'
-require 'jcode'
-$KCODE="UTF8"
 
 port = ARGV[0].to_i
 rubySlim = RubySlim.new

--- a/lib/rubyslim/list_deserializer.rb
+++ b/lib/rubyslim/list_deserializer.rb
@@ -1,5 +1,3 @@
-require 'jcode'
-
 module ListDeserializer
   class SyntaxError < Exception
   end
@@ -31,7 +29,7 @@ module ListDeserializer
         item = @string[@pos...@pos+length_of_item]
         length_in_bytes = length_of_item
 
-        until (item.jlength > length_of_item) do
+        until (item.length > length_of_item) do
           length_in_bytes += 1
           item = @string[@pos...@pos+length_in_bytes]
         end

--- a/lib/rubyslim/list_serializer.rb
+++ b/lib/rubyslim/list_serializer.rb
@@ -1,5 +1,3 @@
-require 'jcode'
-
 module ListSerializer
   # Serialize a list according to the SliM protocol.
   #
@@ -29,7 +27,7 @@ module ListSerializer
       item = "null" if item.nil?
       item = serialize(item) if item.is_a?(Array)
       item = item.to_s
-      result += length_string(item.jlength)
+      result += length_string(item.length)
       result += item + ":"
     end
 

--- a/lib/test_module/should_not_find_test_slim_in_here/test_slim.rb
+++ b/lib/test_module/should_not_find_test_slim_in_here/test_slim.rb
@@ -2,6 +2,6 @@ module TestModule::ShouldNotFindTestSlimInHere
   class TestSlim
     def return_string
       "blah"
-    end    
+    end
   end
 end

--- a/lib/test_module/simple_script.rb
+++ b/lib/test_module/simple_script.rb
@@ -4,6 +4,6 @@ class SimpleScript
   end
 
   def get_arg
-    @arg  
+    @arg
   end
 end

--- a/spec/it8f_spec.rb
+++ b/spec/it8f_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe "characters" do
   it "should be able to deal with it8f chars" do
     "Köln".should == "Köln"
-    "Köln".size.should == 5
+    "Köln".size.should == 4
   end
 end

--- a/spec/list_deserializer_spec.rb
+++ b/spec/list_deserializer_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "list_serializer"
 require "list_deserializer"
@@ -20,7 +21,7 @@ describe ListDeserializer do
   end
 
   it "can't deserialize string that doesn't end with a bracket" do
-    proc {ListDeserializer.deserialize("[000000:")}.should raise_error(ListDeserializer::SyntaxError)    
+    proc {ListDeserializer.deserialize("[000000:")}.should raise_error(ListDeserializer::SyntaxError)
   end
 
   def check()
@@ -41,18 +42,18 @@ describe ListDeserializer do
   it "can deserialize a list with two elements" do
     @list = ["hello", "bob"]
     check
-  end  
+  end
 
   it "can deserialize sublists" do
     @list = ["hello", ["bob", "micah"], "today"]
     check
   end
-  
+
   it "can deserialize lists with multibyte strings" do
     @list = ["Köln"]
     check
-  end 
-  
+  end
+
   it "can deserialize lists of strings that end with multibyte chars" do
     @list = ["Kö"]
     check
@@ -61,6 +62,6 @@ describe ListDeserializer do
   it "can deserialize lists with utf8" do
     @list = ["123456789012345", "Espa\357\277\275ol"]
     check
-  end 
+  end
 
 end

--- a/spec/list_serialzer_spec.rb
+++ b/spec/list_serialzer_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "list_serializer"
 
@@ -15,7 +16,7 @@ describe ListSerializer do
   end
 
   it "can serialize a nested list" do
-    ListSerializer.serialize([["element"]]).should == "[000001:000024:[000001:000007:element:]:]" 
+    ListSerializer.serialize([["element"]]).should == "[000001:000024:[000001:000007:element:]:]"
   end
 
   it "can serialize a list with a non-string" do

--- a/spec/method_invocation_spec.rb
+++ b/spec/method_invocation_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 require "statement_executor"
 
@@ -30,7 +31,7 @@ describe StatementExecutor do
       @test_slim.should_receive(:return_value).and_return("Español")
       val = @executor.call("test_slim", "return_value")
       val.should == "Español"
-      val.jlength.should == 7
+      val.length.should == 7
     end
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,2 @@
 $: << File.expand_path(File.dirname(__FILE__) + "/../lib/rubyslim")
-require "rubygems"
-require "spec"
-require 'jcode'
-$KCODE="UTF8"
 require 'timeout'


### PR DESCRIPTION
- Removed references to jcode.
- Updated tests to use `# coding: utf-8`

Tests pass in 1.9.3 and even in 2.0.0. I'm not sure about 1.8.7 though. Does compatibility need to be maintained?
