### PR TITLE
Added rake to Gemfile to enable bundle exec rake after clone/install.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://www.rubygems.org"
 
 gemspec
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,11 +6,16 @@ PATH
 GEM
   remote: http://www.rubygems.org/
   specs:
+    rake (10.4.2)
     rspec (1.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   rspec (~> 1.3.0)
   rubyslim!
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
On a clean clone followed by `bundle install`, I'm not able to run rake to run the tests.  I got this error message:

```
[~/code/unclebob/rubyslim] bundle exec rake
/Users/russellbevers/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.5/lib/bundler/rubygems_integration.rb:292:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /Users/russellbevers/.rvm/gems/ruby-2.1.6/bin/rake:22:in `<main>'
    from /Users/russellbevers/.rvm/gems/ruby-2.1.6/bin/ruby_executable_hooks:15:in `eval'
    from /Users/russellbevers/.rvm/gems/ruby-2.1.6/bin/ruby_executable_hooks:15:in `<main>'
```

This pull request fixes this for Ruby 2.1.6 w/Bundler 1.10.5.
